### PR TITLE
Omit Counter-Strike Global Offensive

### DIFF
--- a/data/manifest-override.yaml
+++ b/data/manifest-override.yaml
@@ -9,8 +9,8 @@ Overwatch:
   # and its save locations are identical to Overwatch 2,
   # leading to duplicate backups.
   omit: true
-Counter-Strike Global Offensive:
-  # The game is no longer playable at all,
+'Counter-Strike: Global Offensive':
+  # The game is no longer playable unless selected as CS2 beta
   # and its save locations are identical to Counter Strike 2,
   # leading to duplicate backups.
   omit: true

--- a/data/manifest-override.yaml
+++ b/data/manifest-override.yaml
@@ -9,3 +9,8 @@ Overwatch:
   # and its save locations are identical to Overwatch 2,
   # leading to duplicate backups.
   omit: true
+Counter-Strike Global Offensive:
+  # The game is no longer playable at all,
+  # and its save locations are identical to Counter Strike 2,
+  # leading to duplicate backups.
+  omit: true


### PR DESCRIPTION
Counter Strike 2 replaced CSGO, so it should be ignored just like Overwatch